### PR TITLE
FIX: チュートリアル修正

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2-slim
+FROM ruby:3.2.2-slim
 ARG APP_ROOT=/xenn-app
 
 ENV TZ Asia/Tokyo

--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:3.2-slim
+FROM ruby:3.2.2-slim
 
 ENV APP_ROOT /tutorial-app
 ENV TZ Asia/Tokyo

--- a/tutorial_ja.md
+++ b/tutorial_ja.md
@@ -20,8 +20,10 @@ gcloud services enable \
   run.googleapis.com \
   artifactregistry.googleapis.com \
   cloudbuild.googleapis.com \
+  cloudresourcemanager.googleapis.com \
   pubsub.googleapis.com \
   sqladmin.googleapis.com \
+  sql-component.googleapis.com \
   resourcesettings.googleapis.com \
   iam.googleapis.com
 ```

--- a/tutorial_ja.md
+++ b/tutorial_ja.md
@@ -51,7 +51,6 @@ export TF_VAR_primary_region="asia-northeast1"
 export CLOUD_SQL_CONNECTION_HOST="/cloudsql/${GOOGLE_CLOUD_PROJECT}:$TF_VAR_primary_region:xenn-db"
 export CLOUD_SQL_INSTANCE_NAME=$GOOGLE_CLOUD_PROJECT:$TF_VAR_primary_region:xenn-db
 export XENN_CLOUD_RUN_SERVICE_ACCOUNT="xenn-cloud-run-runner@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
-export XENN_CLOUD_RUN_SERVICE_ACCOUNT="xenn-cloud-run-runner@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
 ```
 
 ## Terraform の利用開始


### PR DESCRIPTION
# 変更概要

2024/08/23 にチュートリアルを実施した際にエラーが発生した箇所を修正


# 変更詳細

## 📄 api/Dockerfile, api/Dockerfile.dev

Gemfile では Ruby の 3.2.2 を期待しているが、ベースイメージではパッチバージョンを指定しておらず、
`gcloud builds submit . --tag asia-northeast1-docker.pkg.dev/$GOOGLE_CLOUD_PROJECT/xenn-repo/xenn-api` コマンドによるイメージのビルドに失敗した

エラーメッセージ
```
Your Ruby version is 3.2.5, but your Gemfile specified 3.2.2
The command '/bin/sh -c bundle install' returned a non-zero code: 18
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: step exited with non-zero status: 18
```

## 📄 tutorial_ja.md

以下の点でエラーになったため、最初のステップの API の有効化の項目に追加
- `terraform apply -target module.cloud-run` コマンドの実行時に `cloudresourcemanager.googleapis.com` の有効化が必要であった
- Cloud Run Jobs のデプロイで `sql-component.googleapis.com` の有効化が必要であった

